### PR TITLE
feature (value): moved some shared logic to the component base class

### DIFF
--- a/projects/knora-ui/src/lib/viewer/values/int-value/int-value.component.ts
+++ b/projects/knora-ui/src/lib/viewer/values/int-value/int-value.component.ts
@@ -61,9 +61,7 @@ export class IntValueComponent extends BaseValueComponent implements OnInit, OnC
 
   // unsubscribe when the object is destroyed to prevent memory leaks
   ngOnDestroy(): void {
-    if (this.valueChangesSubscription !== undefined) {
-      this.valueChangesSubscription.unsubscribe();
-    }
+    this.unsubscribeFromValueChanges();
   }
 
   getNewValue(): CreateIntValue | false {

--- a/projects/knora-ui/src/lib/viewer/values/int-value/int-value.component.ts
+++ b/projects/knora-ui/src/lib/viewer/values/int-value/int-value.component.ts
@@ -56,9 +56,7 @@ export class IntValueComponent extends BaseValueComponent implements OnInit, OnC
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (this.valueFormControl !== undefined && this.commentFormControl !== undefined) {
-      this.resetFormControl();
-    }
+    this.resetFormControl();
   }
 
   // unsubscribe when the object is destroyed to prevent memory leaks

--- a/projects/knora-ui/src/lib/viewer/values/text-value/text-value-as-string/text-value-as-string.component.ts
+++ b/projects/knora-ui/src/lib/viewer/values/text-value/text-value-as-string/text-value-as-string.component.ts
@@ -60,15 +60,11 @@ export class TextValueAsStringComponent extends BaseValueComponent implements On
 
     // resets values and validators in form controls when input displayValue or mode changes
     // at the first call of ngOnChanges, form control elements are not initialized yet
-    if (this.valueFormControl !== undefined && this.commentFormControl !== undefined) {
-      this.resetFormControl();
-    }
+    this.resetFormControl();
   }
 
   ngOnDestroy(): void {
-    if (this.valueChangesSubscription !== undefined) {
-      this.valueChangesSubscription.unsubscribe();
-    }
+    this.unsubscribeFromValueChanges();
   }
 
   getNewValue(): CreateTextValueAsString | false {


### PR DESCRIPTION
Moved `if (this.valueFormControl !== undefined && this.commentFormControl !== undefined)` from `ngOnChanges(changes: SimpleChanges): void` within each ValueComponent class to the beginning of `resetFormControl(): void` in the BaseValueComponent class in order to reduce duplication, see https://github.com/dasch-swiss/knora-ui-ng-lib/blob/481cf89db7bd42abba10328467e2c80f88ee1999/projects/knora-ui/src/lib/viewer/values/base-value.component.ts#L80-L103

Also moved the code from each `ngOnDestroy()` method to a new method in the BaseValueComponent class, see https://github.com/dasch-swiss/knora-ui-ng-lib/blob/481cf89db7bd42abba10328467e2c80f88ee1999/projects/knora-ui/src/lib/viewer/values/base-value.component.ts#L108-L112

so that we only need to call the function in the `ngOnDestroy()` method, see https://github.com/dasch-swiss/knora-ui-ng-lib/blob/481cf89db7bd42abba10328467e2c80f88ee1999/projects/knora-ui/src/lib/viewer/values/text-value/text-value-as-string/text-value-as-string.component.ts#L66-L68