### PR TITLE
Boolean value component

### DIFF
--- a/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.html
+++ b/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.html
@@ -2,6 +2,7 @@
   <span [ngSwitch]="displayValue.type">
     <kui-text-value-as-string #displayVal *ngSwitchCase="constants.TextValue" [mode]="mode" [displayValue]="displayValue"></kui-text-value-as-string>
     <kui-int-value #displayVal *ngSwitchCase="constants.IntValue" [mode]="mode" [displayValue]="displayValue"></kui-int-value>
+    <kui-boolean-value #displayVal *ngSwitchCase="constants.BooleanValue" [mode]="mode" [displayValue]="displayValue"></kui-boolean-value>
   </span>
 </div>
 <div>

--- a/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -60,6 +60,26 @@ class TestIntValueComponent implements OnInit {
   }
 }
 
+@Component({
+  selector: `kui-boolean-value`,
+  template: ``
+})
+class TestBooleanValueComponent implements OnInit {
+
+  @Input() mode;
+
+  @Input() displayValue;
+
+  form: object;
+
+  ngOnInit(): void {
+
+    this.form = new FormGroup({
+      test: new FormControl(null, [Validators.required])
+    });
+  }
+}
+
 /**
  * Test host component to simulate parent component.
  */
@@ -116,7 +136,8 @@ describe('DisplayEditComponent', () => {
         DisplayEditComponent,
         TestHostDisplayValueComponent,
         TestTextValueAsStringComponent,
-        TestIntValueComponent
+        TestIntValueComponent,
+        TestBooleanValueComponent
       ],
       providers: [
         {

--- a/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -1,7 +1,7 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import {DisplayEditComponent} from './display-edit.component';
-import {Component, Inject, Input, OnInit, ViewChild} from '@angular/core';
+import { DisplayEditComponent } from './display-edit.component';
+import { Component, Inject, Input, OnInit, ViewChild } from '@angular/core';
 import {
   KnoraApiConnection,
   MockResource,
@@ -14,11 +14,11 @@ import {
   UpdateDecimalValue
 } from '@knora/api';
 
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {By} from '@angular/platform-browser';
-import {FormControl, FormGroup, Validators} from '@angular/forms';
-import {of} from 'rxjs';
-import {KnoraApiConnectionToken} from '../../../core';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { of } from 'rxjs';
+import { KnoraApiConnectionToken } from '../../../core';
 
 @Component({
   selector: `kui-text-value-as-string`,
@@ -95,7 +95,7 @@ class TestDecimalValueComponent implements OnInit {
       test: new FormControl(null, [Validators.required])
     });
   }
-  
+
   getUpdatedValue(): UpdateValue {
     const updateDecimalVal = new UpdateDecimalValue();
 
@@ -116,7 +116,7 @@ class TestDecimalValueComponent implements OnInit {
 })
 class TestHostDisplayValueComponent implements OnInit {
 
-  @ViewChild('displayEditVal', {static: false}) displayEditValueComponent: DisplayEditComponent;
+  @ViewChild('displayEditVal', { static: false }) displayEditValueComponent: DisplayEditComponent;
 
   readResource: ReadResource;
   readValue: ReadValue;
@@ -161,7 +161,7 @@ describe('DisplayEditComponent', () => {
         TestHostDisplayValueComponent,
         TestTextValueAsStringComponent,
         TestIntValueComponent,
-        TestBooleanValueComponent
+        TestBooleanValueComponent,
         TestDecimalValueComponent
       ],
       providers: [

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
@@ -1,6 +1,6 @@
 <span [formGroup]="form">
-    <mat-checkbox [formControlName]="'booleanValue'" class="value boolValue" [disabled]="mode === 'read'" (change)="onChecked(displayValue)">
-        {{displayValue.bool}}
+    <mat-checkbox [formControlName]="'booleanValue'" class="value boolValue" (change)="onChecked($event)">
+        {{booleanLabel}}
     </mat-checkbox>
     <mat-form-field class="large-field">
         <input matInput [formControlName]="'comment'" class="comment boolComment" placeholder="Comment" type="text" [readonly]="mode === 'read'">

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
@@ -1,7 +1,8 @@
 <span [formGroup]="form">
-    <mat-checkbox [formControlName]="'booleanValue'" class="value boolValue">
+    <mat-checkbox [formControlName]="'booleanValue'" class="value boolValue" (change)="onChecked($event)">
+        {{booleanLabel}}
     </mat-checkbox>
-    <mat-form-field class="large-field">
+    <mat-form-field class="large-field comment-field">
         <input matInput [formControlName]="'comment'" class="comment boolComment" placeholder="Comment" type="text"
             [readonly]="mode === 'read'">
     </mat-form-field>

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
@@ -1,1 +1,9 @@
-<p>boolean-value works!</p>
+<span [formGroup]="form">
+    <mat-checkbox [formControlName]="'booleanValue'" class="value boolValue" [disabled]="mode === 'read'">
+        {{displayValue.bool}}
+    </mat-checkbox>
+    <br>
+    <mat-form-field class="large-field">
+        <textarea matInput [formControlName]="'comment'" class="comment boolComment" placeholder="Comment" type="text" [readonly]="mode === 'read'"></textarea>
+    </mat-form-field>
+</span>

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
@@ -1,5 +1,5 @@
 <span [formGroup]="form">
-    <mat-checkbox [formControlName]="'booleanValue'" class="value boolValue" (change)="onChecked($event)">
+    <mat-checkbox [formControlName]="'booleanValue'" class="value boolValue" (change)="onChecked()">
         {{booleanLabel}}
     </mat-checkbox>
     <mat-form-field class="large-field comment-field">

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
@@ -1,9 +1,8 @@
 <span [formGroup]="form">
-    <mat-checkbox [formControlName]="'booleanValue'" class="value boolValue" [disabled]="mode === 'read'">
+    <mat-checkbox [formControlName]="'booleanValue'" class="value boolValue" [disabled]="mode === 'read'" (change)="onChecked(displayValue)">
         {{displayValue.bool}}
     </mat-checkbox>
-    <br>
     <mat-form-field class="large-field">
-        <textarea matInput [formControlName]="'comment'" class="comment boolComment" placeholder="Comment" type="text" [readonly]="mode === 'read'"></textarea>
+        <input matInput [formControlName]="'comment'" class="comment boolComment" placeholder="Comment" type="text" [readonly]="mode === 'read'">
     </mat-form-field>
 </span>

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
@@ -1,0 +1,1 @@
+<p>boolean-value works!</p>

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
@@ -1,8 +1,8 @@
 <span [formGroup]="form">
-    <mat-checkbox [formControlName]="'booleanValue'" class="value boolValue" (change)="onChecked($event)">
-        {{booleanLabel}}
+    <mat-checkbox [formControlName]="'booleanValue'" class="value boolValue">
     </mat-checkbox>
     <mat-form-field class="large-field">
-        <input matInput [formControlName]="'comment'" class="comment boolComment" placeholder="Comment" type="text" [readonly]="mode === 'read'">
+        <input matInput [formControlName]="'comment'" class="comment boolComment" placeholder="Comment" type="text"
+            [readonly]="mode === 'read'">
     </mat-form-field>
 </span>

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.scss
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.scss
@@ -1,0 +1,4 @@
+.comment-field {
+    display: block;
+    max-width: 364px;
+}

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
@@ -3,7 +3,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatCheckboxModule, MatInputModule } from '@angular/material';
 import { BooleanValueComponent } from './boolean-value.component';
 import { Component, OnInit, ViewChild, DebugElement } from '@angular/core';
-import { ReadBooleanValue, MockResource, UpdateBooleanValue } from '@knora/api';
+import { ReadBooleanValue, MockResource, UpdateBooleanValue, CreateBooleanValue } from '@knora/api';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -17,7 +17,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 })
 class TestHostDisplayValueComponent implements OnInit {
 
-  @ViewChild('booleanVal', {static: false}) booleanValueComponent: BooleanValueComponent;
+  @ViewChild('booleanVal', { static: false }) booleanValueComponent: BooleanValueComponent;
 
   displayBooleanVal: ReadBooleanValue;
 
@@ -44,7 +44,7 @@ class TestHostDisplayValueComponent implements OnInit {
 })
 class TestHostCreateValueComponent implements OnInit {
 
-  @ViewChild('booleanVal', {static: false}) booleanValueComponent: BooleanValueComponent;
+  @ViewChild('booleanVal', { static: false }) booleanValueComponent: BooleanValueComponent;
 
   mode: 'read' | 'update' | 'create' | 'search';
 
@@ -57,7 +57,7 @@ describe('BooleanValueComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ 
+      declarations: [
         BooleanValueComponent,
         TestHostDisplayValueComponent,
         TestHostCreateValueComponent
@@ -69,7 +69,7 @@ describe('BooleanValueComponent', () => {
         BrowserAnimationsModule
       ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   describe('display and edit a boolean value', () => {
@@ -79,7 +79,6 @@ describe('BooleanValueComponent', () => {
     let valueBooleanDebugElement: DebugElement;
     let valueBooleanNativeElement;
     let checkboxEl;
-    let checkboxLabel;
     let commentBooleanDebugElement: DebugElement;
     let commentBooleanNativeElement;
 
@@ -96,7 +95,6 @@ describe('BooleanValueComponent', () => {
       valueBooleanDebugElement = valueComponentDe.query(By.css('mat-checkbox'));
       valueBooleanNativeElement = valueBooleanDebugElement.nativeElement;
       checkboxEl = valueBooleanDebugElement.query(By.css('input[type="checkbox"]')).nativeElement;
-      checkboxLabel = valueBooleanDebugElement.query(By.css('span[class="mat-checkbox-label"]')).nativeElement;
 
       commentBooleanDebugElement = valueComponentDe.query(By.css('input.comment'));
       commentBooleanNativeElement = commentBooleanDebugElement.nativeElement;
@@ -112,8 +110,6 @@ describe('BooleanValueComponent', () => {
 
       expect(checkboxEl.disabled).toBe(true);
       expect(checkboxEl.checked).toBe(true);
-
-      expect(checkboxLabel.innerText).toEqual('true');
     });
 
     it('should make an existing value editable', () => {
@@ -130,8 +126,6 @@ describe('BooleanValueComponent', () => {
 
       expect(checkboxEl.checked).toBe(true);
 
-      expect(checkboxLabel.innerText).toEqual('true');
-
       checkboxEl.click();
 
       testHostFixture.detectChanges();
@@ -147,8 +141,6 @@ describe('BooleanValueComponent', () => {
       expect(checkboxEl.checked).toBe(false);
 
       expect(checkboxEl.disabled).toBe(false);
-
-      expect(checkboxLabel.innerText).toEqual('false');
     });
 
     it('should validate an existing value with an added comment', () => {
@@ -164,8 +156,6 @@ describe('BooleanValueComponent', () => {
       expect(testHostComponent.booleanValueComponent.form.valid).toBeFalsy();
 
       expect(checkboxEl.checked).toBe(true);
-
-      expect(checkboxLabel.innerText).toEqual('true');
 
       commentBooleanNativeElement.value = 'this is a comment';
 
@@ -196,15 +186,11 @@ describe('BooleanValueComponent', () => {
 
       expect(checkboxEl.checked).toBe(true);
 
-      expect(checkboxLabel.innerText).toEqual('true');
-
       checkboxEl.click();
 
       testHostFixture.detectChanges();
 
       expect(checkboxEl.checked).toBe(false);
-
-      expect(checkboxLabel.innerText).toEqual('false');
 
       testHostComponent.booleanValueComponent.resetFormControl();
 
@@ -213,9 +199,6 @@ describe('BooleanValueComponent', () => {
       expect(testHostComponent.booleanValueComponent.form.valid).toBeFalsy();
 
       expect(checkboxEl.checked).toBe(true);
-
-      expect(checkboxLabel.innerText).toEqual('true');
-
     });
 
     it('should set a new display value', () => {
@@ -231,10 +214,7 @@ describe('BooleanValueComponent', () => {
 
       expect(checkboxEl.checked).toBe(false);
 
-      expect(checkboxLabel.innerText).toEqual('false');
-
       expect(testHostComponent.booleanValueComponent.form.valid).toBeTruthy();
-
     });
 
     it('should unsubscribe when destroyed', () => {
@@ -246,4 +226,84 @@ describe('BooleanValueComponent', () => {
     });
 
   });
+
+  describe('create a boolean value', () => {
+
+    let testHostComponent: TestHostCreateValueComponent;
+    let testHostFixture: ComponentFixture<TestHostCreateValueComponent>;
+    let valueComponentDe: DebugElement;
+    let valueBooleanDebugElement: DebugElement;
+    let valueBooleanNativeElement;
+    let checkboxEl;
+    let commentBooleanDebugElement: DebugElement;
+    let commentBooleanNativeElement;
+
+    beforeEach(() => {
+
+      testHostFixture = TestBed.createComponent(TestHostCreateValueComponent);
+      testHostComponent = testHostFixture.componentInstance;
+      testHostFixture.detectChanges();
+
+      expect(testHostComponent).toBeTruthy();
+      expect(testHostComponent.booleanValueComponent).toBeTruthy();
+
+      const hostCompDe = testHostFixture.debugElement;
+
+      valueComponentDe = hostCompDe.query(By.directive(BooleanValueComponent));
+      valueBooleanDebugElement = valueComponentDe.query(By.css('mat-checkbox'));
+      valueBooleanNativeElement = valueBooleanDebugElement.nativeElement;
+      checkboxEl = valueBooleanDebugElement.query(By.css('input[type="checkbox"]')).nativeElement;
+      commentBooleanDebugElement = valueComponentDe.query(By.css('input.comment'));
+      commentBooleanNativeElement = commentBooleanDebugElement.nativeElement;
+
+      expect(testHostComponent.booleanValueComponent.displayValue).toEqual(undefined);
+      expect(testHostComponent.booleanValueComponent.form.valid).toBeFalsy();
+      expect(checkboxEl.disabled).toBe(false);
+      expect(checkboxEl.checked).toBe(false);
+      expect(commentBooleanNativeElement.value).toEqual('');
+      expect(commentBooleanNativeElement.readOnly).toEqual(false);
+    });
+
+    it('should create a value', () => {
+
+      checkboxEl.click();
+
+      testHostFixture.detectChanges();
+
+      expect(testHostComponent.booleanValueComponent.mode).toEqual('create');
+
+      expect(testHostComponent.booleanValueComponent.form.valid).toBeTruthy();
+
+      const newValue = testHostComponent.booleanValueComponent.getNewValue();
+
+      expect(newValue instanceof CreateBooleanValue).toBeTruthy();
+
+      expect((newValue as CreateBooleanValue).bool).toEqual(true);
+    });
+
+    it('should reset form after cancellation', () => {
+
+      commentBooleanNativeElement.value = 'created comment';
+
+      commentBooleanNativeElement.dispatchEvent(new Event('input'));
+
+      checkboxEl.click();
+
+      testHostFixture.detectChanges();
+
+      expect(testHostComponent.booleanValueComponent.mode).toEqual('create');
+
+      expect(testHostComponent.booleanValueComponent.form.valid).toBeTruthy();
+
+      testHostComponent.booleanValueComponent.resetFormControl();
+
+      expect(testHostComponent.booleanValueComponent.form.valid).toBeFalsy();
+
+      expect(checkboxEl.checked).toBe(true);
+
+      expect(commentBooleanNativeElement.value).toEqual('');
+
+    });
+  });
+
 });

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
@@ -1,25 +1,118 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatCheckboxModule, MatInputModule } from '@angular/material';
 import { BooleanValueComponent } from './boolean-value.component';
+import { Component, OnInit, ViewChild, DebugElement } from '@angular/core';
+import { ReadBooleanValue, MockResource } from '@knora/api';
+import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+
+/**
+ * Test host component to simulate parent component.
+ */
+@Component({
+  template: `
+  <kui-boolean-value #booleanVal [displayValue]="displayBooleanVal" [mode]="mode"></kui-boolean-value>`
+})
+class TestHostDisplayValueComponent implements OnInit {
+
+  @ViewChild('booleanVal', {static: false}) booleanValueComponent: BooleanValueComponent;
+
+  displayBooleanVal: ReadBooleanValue;
+
+  mode: 'read' | 'update' | 'create' | 'search';
+
+  ngOnInit() {
+    MockResource.getTestthing().subscribe(res => {
+      const booleanVal: ReadBooleanValue = 
+        res[0].getValuesAs('http://0.0.0.0:3333/ontology/0001/anything/v2#hasBoolean', ReadBooleanValue)[0];
+
+      this.displayBooleanVal = booleanVal;
+
+      this.mode = 'read';
+    });
+  }
+}
+
+/**
+ * Test host component to simulate parent component.
+ */
+@Component({
+  template: `
+  <kui-boolean-value #booleanVal [mode]="mode"></kui-boolean-value>`
+})
+class TestHostCreateValueComponent implements OnInit {
+
+  @ViewChild('booleanVal', {static: false}) booleanValueComponent: BooleanValueComponent;
+
+  mode: 'read' | 'update' | 'create' | 'search';
+
+  ngOnInit() {
+    this.mode = 'create';
+  }
+}
 
 describe('BooleanValueComponent', () => {
-  let component: BooleanValueComponent;
-  let fixture: ComponentFixture<BooleanValueComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BooleanValueComponent ]
+      declarations: [ 
+        BooleanValueComponent,
+        TestHostDisplayValueComponent,
+        TestHostCreateValueComponent
+      ],
+      imports: [
+        ReactiveFormsModule,
+        MatCheckboxModule,
+        MatInputModule,
+        BrowserAnimationsModule
+      ]
     })
     .compileComponents();
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(BooleanValueComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+  describe('display and edit a boolean value', () => {
+    let testHostComponent: TestHostDisplayValueComponent;
+    let testHostFixture: ComponentFixture<TestHostDisplayValueComponent>;
+    let valueComponentDe: DebugElement;
+    let valueBooleanDebugElement: DebugElement;
+    let valueBooleanNativeElement;
+    let commentBooleanDebugElement: DebugElement;
+    let commentBooleanNativeElement;
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+    beforeEach(() => {
+      testHostFixture = TestBed.createComponent(TestHostDisplayValueComponent);
+      testHostComponent = testHostFixture.componentInstance;
+      testHostFixture.detectChanges();
+
+      expect(testHostComponent).toBeTruthy();
+      expect(testHostComponent.booleanValueComponent).toBeTruthy();
+
+      const hostCompDe = testHostFixture.debugElement;
+      valueComponentDe = hostCompDe.query(By.directive(BooleanValueComponent));
+      valueBooleanDebugElement = valueComponentDe.query(By.css('mat-checkbox'));
+      valueBooleanNativeElement = valueBooleanDebugElement.nativeElement;
+
+      commentBooleanDebugElement = valueComponentDe.query(By.css('input.comment'));
+      commentBooleanNativeElement = commentBooleanDebugElement.nativeElement;
+    });
+
+    it('should display an existing value', () => {
+
+      expect(testHostComponent.booleanValueComponent.displayValue.bool).toEqual(true);
+
+      expect(testHostComponent.booleanValueComponent.form.valid).toBeTruthy();
+
+      expect(testHostComponent.booleanValueComponent.mode).toEqual('read');
+
+      const checkboxEl = valueBooleanDebugElement.query(By.css('input[type="checkbox"]')).nativeElement;
+      expect(checkboxEl.disabled).toBe(true);
+      expect(checkboxEl.checked).toBe(true);
+
+      const checkboxLabel = valueBooleanDebugElement.query(By.css('span[class="mat-checkbox-label"]')).nativeElement;
+      expect(checkboxLabel.innerText).toEqual('true');
+    });
+
   });
 });

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
@@ -285,8 +285,6 @@ describe('BooleanValueComponent', () => {
 
     it('should create a value', () => {
 
-      console.log('valueBooleanDebugElement', valueBooleanDebugElement);
-
       checkboxEl.click();
 
       testHostFixture.detectChanges();

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BooleanValueComponent } from './boolean-value.component';
+
+describe('BooleanValueComponent', () => {
+  let component: BooleanValueComponent;
+  let fixture: ComponentFixture<BooleanValueComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ BooleanValueComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BooleanValueComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
@@ -79,6 +79,7 @@ describe('BooleanValueComponent', () => {
     let valueBooleanDebugElement: DebugElement;
     let valueBooleanNativeElement;
     let checkboxEl;
+    let checkboxLabel;
     let commentBooleanDebugElement: DebugElement;
     let commentBooleanNativeElement;
 
@@ -95,6 +96,7 @@ describe('BooleanValueComponent', () => {
       valueBooleanDebugElement = valueComponentDe.query(By.css('mat-checkbox'));
       valueBooleanNativeElement = valueBooleanDebugElement.nativeElement;
       checkboxEl = valueBooleanDebugElement.query(By.css('input[type="checkbox"]')).nativeElement;
+      checkboxLabel = valueBooleanDebugElement.query(By.css('span[class="mat-checkbox-label"]')).nativeElement;
 
       commentBooleanDebugElement = valueComponentDe.query(By.css('input.comment'));
       commentBooleanNativeElement = commentBooleanDebugElement.nativeElement;
@@ -110,6 +112,8 @@ describe('BooleanValueComponent', () => {
 
       expect(checkboxEl.disabled).toBe(true);
       expect(checkboxEl.checked).toBe(true);
+
+      expect(checkboxLabel.innerText).toEqual('true');
     });
 
     it('should make an existing value editable', () => {
@@ -126,6 +130,8 @@ describe('BooleanValueComponent', () => {
 
       expect(checkboxEl.checked).toBe(true);
 
+      expect(checkboxLabel.innerText).toEqual('true');
+
       checkboxEl.click();
 
       testHostFixture.detectChanges();
@@ -141,6 +147,8 @@ describe('BooleanValueComponent', () => {
       expect(checkboxEl.checked).toBe(false);
 
       expect(checkboxEl.disabled).toBe(false);
+
+      expect(checkboxLabel.innerText).toEqual('false');
     });
 
     it('should validate an existing value with an added comment', () => {
@@ -156,6 +164,8 @@ describe('BooleanValueComponent', () => {
       expect(testHostComponent.booleanValueComponent.form.valid).toBeFalsy();
 
       expect(checkboxEl.checked).toBe(true);
+
+      expect(checkboxLabel.innerText).toEqual('true');
 
       commentBooleanNativeElement.value = 'this is a comment';
 
@@ -186,11 +196,15 @@ describe('BooleanValueComponent', () => {
 
       expect(checkboxEl.checked).toBe(true);
 
+      expect(checkboxLabel.innerText).toEqual('true');
+
       checkboxEl.click();
 
       testHostFixture.detectChanges();
 
       expect(checkboxEl.checked).toBe(false);
+
+      expect(checkboxLabel.innerText).toEqual('false');
 
       testHostComponent.booleanValueComponent.resetFormControl();
 
@@ -199,6 +213,8 @@ describe('BooleanValueComponent', () => {
       expect(testHostComponent.booleanValueComponent.form.valid).toBeFalsy();
 
       expect(checkboxEl.checked).toBe(true);
+
+      expect(checkboxLabel.innerText).toEqual('true');
     });
 
     it('should set a new display value', () => {
@@ -235,6 +251,7 @@ describe('BooleanValueComponent', () => {
     let valueBooleanDebugElement: DebugElement;
     let valueBooleanNativeElement;
     let checkboxEl;
+    let checkboxLabel;
     let commentBooleanDebugElement: DebugElement;
     let commentBooleanNativeElement;
 
@@ -253,6 +270,7 @@ describe('BooleanValueComponent', () => {
       valueBooleanDebugElement = valueComponentDe.query(By.css('mat-checkbox'));
       valueBooleanNativeElement = valueBooleanDebugElement.nativeElement;
       checkboxEl = valueBooleanDebugElement.query(By.css('input[type="checkbox"]')).nativeElement;
+      checkboxLabel = valueBooleanDebugElement.query(By.css('span[class="mat-checkbox-label"]')).nativeElement;
       commentBooleanDebugElement = valueComponentDe.query(By.css('input.comment'));
       commentBooleanNativeElement = commentBooleanDebugElement.nativeElement;
 
@@ -260,11 +278,14 @@ describe('BooleanValueComponent', () => {
       expect(testHostComponent.booleanValueComponent.form.valid).toBeFalsy();
       expect(checkboxEl.disabled).toBe(false);
       expect(checkboxEl.checked).toBe(false);
+      expect(checkboxLabel.innerText).toEqual('false');
       expect(commentBooleanNativeElement.value).toEqual('');
       expect(commentBooleanNativeElement.readOnly).toEqual(false);
     });
 
     it('should create a value', () => {
+
+      console.log('valueBooleanDebugElement', valueBooleanDebugElement);
 
       checkboxEl.click();
 

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
@@ -72,7 +72,7 @@ describe('BooleanValueComponent', () => {
     .compileComponents();
   }));
 
-  describe('display and edit a boolean value', () => {
+  fdescribe('display and edit a boolean value', () => {
     let testHostComponent: TestHostDisplayValueComponent;
     let testHostFixture: ComponentFixture<TestHostDisplayValueComponent>;
     let valueComponentDe: DebugElement;
@@ -142,13 +142,80 @@ describe('BooleanValueComponent', () => {
 
       expect(updatedValue instanceof UpdateBooleanValue).toBeTruthy();
 
-      // todo: fix expect((updatedValue instanceof UpdateBooleanValue).valueOf()).toBe(false);
+      expect((updatedValue as UpdateBooleanValue).bool).toBe(false);
 
       expect(checkboxEl.checked).toBe(false);
 
       expect(checkboxEl.disabled).toBe(false);
 
       expect(checkboxLabel.innerText).toEqual('false');
+    });
+
+    it('should validate an existing value with an added comment', () => {
+
+      testHostComponent.mode = 'update';
+
+      testHostFixture.detectChanges();
+
+      expect(testHostComponent.booleanValueComponent.mode).toEqual('update');
+
+      expect(checkboxEl.disabled).toBe(false);
+
+      expect(testHostComponent.booleanValueComponent.form.valid).toBeFalsy();
+
+      expect(checkboxEl.checked).toBe(true);
+
+      expect(checkboxLabel.innerText).toEqual('true');
+
+      commentBooleanNativeElement.value = 'this is a comment';
+
+      commentBooleanNativeElement.dispatchEvent(new Event('input'));
+
+      testHostFixture.detectChanges();
+
+      expect(testHostComponent.booleanValueComponent.form.valid).toBeTruthy();
+
+      const updatedValue = testHostComponent.booleanValueComponent.getUpdatedValue();
+
+      expect(updatedValue instanceof UpdateBooleanValue).toBeTruthy();
+
+      expect((updatedValue as UpdateBooleanValue).valueHasComment).toEqual('this is a comment');
+    });
+
+    fit('should restore the initially displayed value', () => {
+
+      testHostComponent.mode = 'update';
+
+      testHostFixture.detectChanges();
+
+      expect(testHostComponent.booleanValueComponent.mode).toEqual('update');
+
+      expect(checkboxEl.disabled).toBe(false);
+
+      expect(testHostComponent.booleanValueComponent.form.valid).toBeFalsy();
+
+      expect(checkboxEl.checked).toBe(true);
+
+      expect(checkboxLabel.innerText).toEqual('true');
+
+      checkboxEl.click();
+
+      testHostFixture.detectChanges();
+
+      expect(checkboxEl.checked).toBe(false);
+
+      expect(checkboxLabel.innerText).toEqual('false');
+
+      testHostComponent.booleanValueComponent.resetFormControl();
+
+      testHostFixture.detectChanges();
+
+      expect(testHostComponent.booleanValueComponent.form.valid).toBeFalsy();
+
+      expect(checkboxEl.checked).toBe(true);
+
+      expect(checkboxLabel.innerText).toEqual('true');
+
     });
 
   });

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
@@ -25,7 +25,7 @@ class TestHostDisplayValueComponent implements OnInit {
 
   ngOnInit() {
     MockResource.getTestthing().subscribe(res => {
-      const booleanVal: ReadBooleanValue = 
+      const booleanVal: ReadBooleanValue =
         res[0].getValuesAs('http://0.0.0.0:3333/ontology/0001/anything/v2#hasBoolean', ReadBooleanValue)[0];
 
       this.displayBooleanVal = booleanVal;
@@ -72,7 +72,7 @@ describe('BooleanValueComponent', () => {
     .compileComponents();
   }));
 
-  fdescribe('display and edit a boolean value', () => {
+  describe('display and edit a boolean value', () => {
     let testHostComponent: TestHostDisplayValueComponent;
     let testHostFixture: ComponentFixture<TestHostDisplayValueComponent>;
     let valueComponentDe: DebugElement;
@@ -182,7 +182,7 @@ describe('BooleanValueComponent', () => {
       expect((updatedValue as UpdateBooleanValue).valueHasComment).toEqual('this is a comment');
     });
 
-    fit('should restore the initially displayed value', () => {
+    it('should restore the initially displayed value', () => {
 
       testHostComponent.mode = 'update';
 
@@ -216,6 +216,33 @@ describe('BooleanValueComponent', () => {
 
       expect(checkboxLabel.innerText).toEqual('true');
 
+    });
+
+    it('should set a new display value', () => {
+
+      const newBool = new ReadBooleanValue();
+
+      newBool.bool = false;
+      newBool.id = 'updatedId';
+
+      testHostComponent.displayBooleanVal = newBool;
+
+      testHostFixture.detectChanges();
+
+      expect(checkboxEl.checked).toBe(false);
+
+      expect(checkboxLabel.innerText).toEqual('false');
+
+      expect(testHostComponent.booleanValueComponent.form.valid).toBeTruthy();
+
+    });
+
+    it('should unsubscribe when destroyed', () => {
+      expect(testHostComponent.booleanValueComponent.valueChangesSubscription.closed).toBeFalsy();
+
+      testHostComponent.booleanValueComponent.ngOnDestroy();
+
+      expect(testHostComponent.booleanValueComponent.valueChangesSubscription.closed).toBeTruthy();
     });
 
   });

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.spec.ts
@@ -3,7 +3,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatCheckboxModule, MatInputModule } from '@angular/material';
 import { BooleanValueComponent } from './boolean-value.component';
 import { Component, OnInit, ViewChild, DebugElement } from '@angular/core';
-import { ReadBooleanValue, MockResource } from '@knora/api';
+import { ReadBooleanValue, MockResource, UpdateBooleanValue } from '@knora/api';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -78,6 +78,8 @@ describe('BooleanValueComponent', () => {
     let valueComponentDe: DebugElement;
     let valueBooleanDebugElement: DebugElement;
     let valueBooleanNativeElement;
+    let checkboxEl;
+    let checkboxLabel;
     let commentBooleanDebugElement: DebugElement;
     let commentBooleanNativeElement;
 
@@ -93,6 +95,8 @@ describe('BooleanValueComponent', () => {
       valueComponentDe = hostCompDe.query(By.directive(BooleanValueComponent));
       valueBooleanDebugElement = valueComponentDe.query(By.css('mat-checkbox'));
       valueBooleanNativeElement = valueBooleanDebugElement.nativeElement;
+      checkboxEl = valueBooleanDebugElement.query(By.css('input[type="checkbox"]')).nativeElement;
+      checkboxLabel = valueBooleanDebugElement.query(By.css('span[class="mat-checkbox-label"]')).nativeElement;
 
       commentBooleanDebugElement = valueComponentDe.query(By.css('input.comment'));
       commentBooleanNativeElement = commentBooleanDebugElement.nativeElement;
@@ -106,12 +110,45 @@ describe('BooleanValueComponent', () => {
 
       expect(testHostComponent.booleanValueComponent.mode).toEqual('read');
 
-      const checkboxEl = valueBooleanDebugElement.query(By.css('input[type="checkbox"]')).nativeElement;
       expect(checkboxEl.disabled).toBe(true);
       expect(checkboxEl.checked).toBe(true);
 
-      const checkboxLabel = valueBooleanDebugElement.query(By.css('span[class="mat-checkbox-label"]')).nativeElement;
       expect(checkboxLabel.innerText).toEqual('true');
+    });
+
+    it('should make an existing value editable', () => {
+
+      testHostComponent.mode = 'update';
+
+      testHostFixture.detectChanges();
+
+      expect(testHostComponent.booleanValueComponent.mode).toEqual('update');
+
+      expect(checkboxEl.disabled).toBe(false);
+
+      expect(testHostComponent.booleanValueComponent.form.valid).toBeFalsy();
+
+      expect(checkboxEl.checked).toBe(true);
+
+      expect(checkboxLabel.innerText).toEqual('true');
+
+      checkboxEl.click();
+
+      testHostFixture.detectChanges();
+
+      expect(testHostComponent.booleanValueComponent.form.valid).toBeTruthy();
+
+      const updatedValue = testHostComponent.booleanValueComponent.getUpdatedValue();
+
+      expect(updatedValue instanceof UpdateBooleanValue).toBeTruthy();
+
+      // todo: fix expect((updatedValue instanceof UpdateBooleanValue).valueOf()).toBe(false);
+
+      expect(checkboxEl.checked).toBe(false);
+
+      expect(checkboxEl.disabled).toBe(false);
+
+      expect(checkboxLabel.innerText).toEqual('false');
     });
 
   });

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.ts
@@ -1,9 +1,9 @@
-import { Component, OnInit, OnChanges, OnDestroy, Input, Inject, SimpleChanges } from '@angular/core';
-import { BaseValueComponent } from '../base-value.component';
-import { ReadBooleanValue, CreateBooleanValue, UpdateBooleanValue } from '@knora/api';
-import { FormControl, FormGroup, FormBuilder } from '@angular/forms';
-import { Subscription } from 'rxjs';
+import { Component, Inject, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { MatCheckboxChange } from '@angular/material/typings';
+import { CreateBooleanValue, ReadBooleanValue, UpdateBooleanValue } from '@knora/api';
+import { Subscription } from 'rxjs';
+import { BaseValueComponent } from '../base-value.component';
 
 @Component({
   selector: 'kui-boolean-value',
@@ -22,6 +22,8 @@ export class BooleanValueComponent extends BaseValueComponent implements OnInit,
   valueChangesSubscription: Subscription;
 
   customValidators = [];
+
+  booleanLabel: string;
 
   constructor(@Inject(FormBuilder) private fb: FormBuilder) {
     super();
@@ -55,6 +57,21 @@ export class BooleanValueComponent extends BaseValueComponent implements OnInit,
     this.resetFormControl();
   }
 
+  // override the resetFormControl() from the base component to deal with the disabled state and the checkbox label
+  resetFormControl(): void {
+    super.resetFormControl();
+
+    if (this.valueFormControl !== undefined) {
+      this.booleanLabel = this.valueFormControl.value ? 'true' : 'false';
+      if (this.mode === 'read') {
+        this.valueFormControl.disable();
+      } else {
+        this.valueFormControl.enable();
+      }
+    }
+
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
     this.resetFormControl();
   }
@@ -63,19 +80,6 @@ export class BooleanValueComponent extends BaseValueComponent implements OnInit,
   ngOnDestroy(): void {
     this.unsubscribeFromValueChanges();
   }
-
-  resetFormControl(): void {
-    super.resetFormControl();
-
-    if (this.valueFormControl !== undefined) {
-      if (this.mode === 'read') {
-        this.valueFormControl.disable();
-      } else {
-        this.valueFormControl.enable();
-      }
-    }
-  }
-
 
   getNewValue(): CreateBooleanValue | false {
     if (this.mode !== 'create' || !this.form.valid) {
@@ -111,6 +115,11 @@ export class BooleanValueComponent extends BaseValueComponent implements OnInit,
     }
 
     return updatedBooleanValue;
+  }
+
+  // update dynamically the checkbox label according to the checked status
+  onChecked(changeEvent: MatCheckboxChange) {
+    this.booleanLabel = changeEvent.checked.toString();
   }
 
 }

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.ts
@@ -3,6 +3,7 @@ import { BaseValueComponent } from '../base-value.component';
 import { ReadBooleanValue, CreateBooleanValue, UpdateBooleanValue } from '@knora/api';
 import { FormControl, FormGroup, FormBuilder } from '@angular/forms';
 import { Subscription } from 'rxjs';
+import { MatCheckboxChange } from '@angular/material/typings';
 
 @Component({
   selector: 'kui-boolean-value',
@@ -22,12 +23,15 @@ export class BooleanValueComponent extends BaseValueComponent implements OnInit,
 
   customValidators = [];
 
+  booleanLabel: string;
+
   constructor(@Inject(FormBuilder) private fb: FormBuilder) {
     super();
   }
 
   getInitValue(): boolean | null {
     if (this.displayValue !== undefined) {
+      console.log('getInitValue', this.displayValue.bool);
       return this.displayValue.bool;
     } else {
       return null;
@@ -52,6 +56,20 @@ export class BooleanValueComponent extends BaseValueComponent implements OnInit,
     });
 
     this.resetFormControl();
+  }
+
+  resetFormControl(): void {
+    super.resetFormControl();
+
+    if (this.valueFormControl !== undefined) {
+      this.booleanLabel = this.getInitValue().toString();
+      if (this.mode === 'read') {
+        this.valueFormControl.disable();
+      } else {
+        this.valueFormControl.enable();
+      }
+    }
+
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -100,8 +118,8 @@ export class BooleanValueComponent extends BaseValueComponent implements OnInit,
   }
 
   // update dynamically the checkbox label according to the checked status
-  onChecked(displayValue: ReadBooleanValue) {
-    displayValue.bool = !displayValue.bool;
+  onChecked(changeEvent: MatCheckboxChange) {
+    this.booleanLabel = changeEvent.checked.toString();
   }
 
 }

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.ts
@@ -62,7 +62,7 @@ export class BooleanValueComponent extends BaseValueComponent implements OnInit,
     super.resetFormControl();
 
     if (this.valueFormControl !== undefined) {
-      this.booleanLabel = this.valueFormControl.value ? 'true' : 'false';
+      this.setBoolLabel();
       if (this.mode === 'read') {
         this.valueFormControl.disable();
       } else {
@@ -118,8 +118,13 @@ export class BooleanValueComponent extends BaseValueComponent implements OnInit,
   }
 
   // update dynamically the checkbox label according to the checked status
-  onChecked(changeEvent: MatCheckboxChange) {
-    this.booleanLabel = changeEvent.checked.toString();
+  onChecked() {
+    this.setBoolLabel();
+  }
+
+  private setBoolLabel(): string {
+    this.booleanLabel = this.valueFormControl.value ? 'true' : 'false';
+    return this.booleanLabel;
   }
 
 }

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.ts
@@ -1,15 +1,102 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnChanges, OnDestroy, Input, Inject, SimpleChanges } from '@angular/core';
+import { BaseValueComponent } from '../base-value.component';
+import { ReadBooleanValue, CreateBooleanValue, UpdateBooleanValue } from '@knora/api';
+import { FormControl, FormGroup, FormBuilder } from '@angular/forms';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'kui-boolean-value',
   templateUrl: './boolean-value.component.html',
   styleUrls: ['./boolean-value.component.scss']
 })
-export class BooleanValueComponent implements OnInit {
+export class BooleanValueComponent extends BaseValueComponent implements OnInit, OnChanges, OnDestroy {
 
-  constructor() { }
+  @Input() displayValue?: ReadBooleanValue;
+
+  valueFormControl: FormControl;
+  commentFormControl: FormControl;
+
+  form: FormGroup;
+
+  valueChangesSubscription: Subscription;
+
+  customValidators = [];
+
+  constructor(@Inject(FormBuilder) private fb: FormBuilder) {
+    super();
+  }
+
+  getInitValue(): boolean | null {
+    if (this.displayValue !== undefined) {
+      return this.displayValue.bool;
+    } else {
+      return null;
+    }
+  }
 
   ngOnInit() {
+    // initialize form control elements
+    this.valueFormControl = new FormControl(null);
+    this.commentFormControl = new FormControl(null);
+
+    // subscribe to any change on the comment and recheck validity
+    this.valueChangesSubscription = this.commentFormControl.valueChanges.subscribe(
+      data => {
+        this.valueFormControl.updateValueAndValidity();
+      }
+    );
+
+    this.form = this.fb.group({
+      booleanValue: this.valueFormControl,
+      comment: this.commentFormControl
+    });
+
+    this.resetFormControl();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    this.resetFormControl();
+  }
+
+  // unsubscribe when the object is destroyed to prevent memory leaks
+  ngOnDestroy(): void {
+    this.unsubscribeFromValueChanges();
+  }
+
+  getNewValue(): CreateBooleanValue | false {
+    if (this.mode !== 'create' || !this.form.valid) {
+      return false;
+    }
+
+    const newBooleanValue = new CreateBooleanValue();
+
+    newBooleanValue.bool = this.valueFormControl.value;
+
+    // add the submitted new comment to newBooleanValue only if the user has added a comment
+    if (this.commentFormControl.value !== null && this.commentFormControl.value !== '') {
+      newBooleanValue.valueHasComment = this.commentFormControl.value;
+    }
+
+    return newBooleanValue;
+  }
+
+  getUpdatedValue(): UpdateBooleanValue | false {
+    if (this.mode !== 'update' || !this.form.valid) {
+      return false;
+    }
+
+    const updatedBooleanValue = new UpdateBooleanValue();
+
+    updatedBooleanValue.id = this.displayValue.id;
+
+    updatedBooleanValue.bool = this.valueFormControl.value;
+
+    // add the submitted comment to updatedBooleanValue only if user has added a comment
+    if (this.commentFormControl.value !== null && this.commentFormControl.value !== '') {
+      updatedBooleanValue.valueHasComment = this.commentFormControl.value;
+    }
+
+    return updatedBooleanValue;
   }
 
 }

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.ts
@@ -99,4 +99,9 @@ export class BooleanValueComponent extends BaseValueComponent implements OnInit,
     return updatedBooleanValue;
   }
 
+  // update dynamically the checkbox label according to the checked status
+  onChecked(displayValue: ReadBooleanValue) {
+    displayValue.bool = !displayValue.bool;
+  }
+
 }

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'kui-boolean-value',
+  templateUrl: './boolean-value.component.html',
+  styleUrls: ['./boolean-value.component.scss']
+})
+export class BooleanValueComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.ts
+++ b/projects/knora-ui/src/lib/viewer/values/boolean-value/boolean-value.component.ts
@@ -23,15 +23,12 @@ export class BooleanValueComponent extends BaseValueComponent implements OnInit,
 
   customValidators = [];
 
-  booleanLabel: string;
-
   constructor(@Inject(FormBuilder) private fb: FormBuilder) {
     super();
   }
 
   getInitValue(): boolean | null {
     if (this.displayValue !== undefined) {
-      console.log('getInitValue', this.displayValue.bool);
       return this.displayValue.bool;
     } else {
       return null;
@@ -58,20 +55,6 @@ export class BooleanValueComponent extends BaseValueComponent implements OnInit,
     this.resetFormControl();
   }
 
-  resetFormControl(): void {
-    super.resetFormControl();
-
-    if (this.valueFormControl !== undefined) {
-      this.booleanLabel = this.getInitValue().toString();
-      if (this.mode === 'read') {
-        this.valueFormControl.disable();
-      } else {
-        this.valueFormControl.enable();
-      }
-    }
-
-  }
-
   ngOnChanges(changes: SimpleChanges): void {
     this.resetFormControl();
   }
@@ -80,6 +63,19 @@ export class BooleanValueComponent extends BaseValueComponent implements OnInit,
   ngOnDestroy(): void {
     this.unsubscribeFromValueChanges();
   }
+
+  resetFormControl(): void {
+    super.resetFormControl();
+
+    if (this.valueFormControl !== undefined) {
+      if (this.mode === 'read') {
+        this.valueFormControl.disable();
+      } else {
+        this.valueFormControl.enable();
+      }
+    }
+  }
+
 
   getNewValue(): CreateBooleanValue | false {
     if (this.mode !== 'create' || !this.form.valid) {
@@ -115,11 +111,6 @@ export class BooleanValueComponent extends BaseValueComponent implements OnInit,
     }
 
     return updatedBooleanValue;
-  }
-
-  // update dynamically the checkbox label according to the checked status
-  onChecked(changeEvent: MatCheckboxChange) {
-    this.booleanLabel = changeEvent.checked.toString();
   }
 
 }

--- a/projects/knora-ui/src/lib/viewer/values/int-value/int-value.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/values/int-value/int-value.component.spec.ts
@@ -18,7 +18,7 @@ import { By } from '@angular/platform-browser';
 })
 class TestHostDisplayValueComponent implements OnInit {
 
-  @ViewChild('inputVal', {static: false}) inputValueComponent: IntValueComponent;
+  @ViewChild('inputVal', { static: false }) inputValueComponent: IntValueComponent;
 
   displayInputVal: ReadIntValue;
 
@@ -47,7 +47,7 @@ class TestHostDisplayValueComponent implements OnInit {
 })
 class TestHostCreateValueComponent implements OnInit {
 
-  @ViewChild('inputVal', {static: false}) inputValueComponent: IntValueComponent;
+  @ViewChild('inputVal', { static: false }) inputValueComponent: IntValueComponent;
 
   mode: 'read' | 'update' | 'create' | 'search';
 
@@ -62,20 +62,20 @@ describe('IntValueComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ 
+      declarations: [
         IntValueComponent,
         TestHostDisplayValueComponent,
         TestHostCreateValueComponent
-       ],
-       imports: [
+      ],
+      imports: [
         ReactiveFormsModule,
         MatInputModule,
         BrowserAnimationsModule
       ],
     })
-    .compileComponents();
+      .compileComponents();
   }));
-  
+
   describe('display and edit an integer value', () => {
     let testHostComponent: TestHostDisplayValueComponent;
     let testHostFixture: ComponentFixture<TestHostDisplayValueComponent>;

--- a/projects/knora-ui/src/lib/viewer/viewer.module.ts
+++ b/projects/knora-ui/src/lib/viewer/viewer.module.ts
@@ -1,7 +1,8 @@
 import {NgModule} from '@angular/core';
 import {TextValueAsStringComponent} from './values/text-value/text-value-as-string/text-value-as-string.component';
 import {ReactiveFormsModule} from '@angular/forms';
-import {MatInputModule} from '@angular/material';
+import {MatInputModule} from '@angular/material/input';
+import {MatCheckboxModule} from '@angular/material/checkbox';
 import {CommonModule} from '@angular/common';
 import { IntValueComponent } from './values/int-value/int-value.component';
 import { DisplayEditComponent } from './operations/display-edit/display-edit.component';
@@ -12,7 +13,8 @@ import { BooleanValueComponent } from './values/boolean-value/boolean-value.comp
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    MatInputModule
+    MatInputModule,
+    MatCheckboxModule
   ],
   exports: [TextValueAsStringComponent, IntValueComponent, DisplayEditComponent]
 })

--- a/projects/knora-ui/src/lib/viewer/viewer.module.ts
+++ b/projects/knora-ui/src/lib/viewer/viewer.module.ts
@@ -5,9 +5,10 @@ import {MatInputModule} from '@angular/material';
 import {CommonModule} from '@angular/common';
 import { IntValueComponent } from './values/int-value/int-value.component';
 import { DisplayEditComponent } from './operations/display-edit/display-edit.component';
+import { BooleanValueComponent } from './values/boolean-value/boolean-value.component';
 
 @NgModule({
-  declarations: [TextValueAsStringComponent, IntValueComponent, DisplayEditComponent],
+  declarations: [TextValueAsStringComponent, IntValueComponent, DisplayEditComponent, BooleanValueComponent],
   imports: [
     CommonModule,
     ReactiveFormsModule,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -32,7 +32,7 @@ export class AppComponent implements OnInit {
       (resource: ReadResource) => {
         this.testthing = resource;
         console.log(this.testthing);
-        this.testValue = this.testthing.getValues('http://0.0.0.0:3333/ontology/0001/anything/v2#hasText')[0];
+        this.testValue = this.testthing.getValues('http://0.0.0.0:3333/ontology/0001/anything/v2#hasBoolean')[0];
       }
     );
 


### PR DESCRIPTION
closes #9 

Used checkbox instead of slide toggle because we should use a checkbox in case of a settings confirmation - which the most common case in Knora projects(see [this article](https://uxplanet.org/checkbox-vs-toggle-switch-7fc6e83f10b8))