### PR TITLE
Mock KnoraApiConnection in Tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: git clone -b wip/121-mock-factory --single-branch --depth 1 https://github.com/dasch-swiss/knora-api-js-lib
-    - run: cd knora-api-js-lib && npm install yalc -g && npm install && npm run yalc-publish
+    - run: cd knora-api-js-lib && npm install yalc -g && npm install && npm run yalc-publish # each 'run' is executed from project root
     - run: yalc add @knora/api
     - run: npm install
     - run: npm run test-lib

--- a/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -76,9 +76,6 @@ class TestHostDisplayValueComponent implements OnInit {
 
   mode: 'read' | 'update' | 'create' | 'search';
 
-  constructor(@Inject(KnoraApiConnectionToken) private knoraApiConnection: KnoraApiConnection) {
-  }
-
   ngOnInit() {
 
     MockResource.getTestthing().subscribe(res => {

--- a/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -1,9 +1,8 @@
-import {async, ComponentFixture, inject, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {DisplayEditComponent} from './display-edit.component';
 import {Component, Inject, Input, OnInit, ViewChild} from '@angular/core';
 import {
-  KnoraApiConfig,
   KnoraApiConnection,
   MockResource,
   ReadIntValue,
@@ -100,13 +99,14 @@ class TestHostDisplayValueComponent implements OnInit {
 describe('DisplayEditComponent', () => {
   let testHostComponent: TestHostDisplayValueComponent;
   let testHostFixture: ComponentFixture<TestHostDisplayValueComponent>;
-  let config: KnoraApiConfig;
-  let knoraApiConnection: KnoraApiConnection;
 
   beforeEach(async(() => {
 
-    config = new KnoraApiConfig('http', '0.0.0.0', 3333, undefined, undefined, true);
-    knoraApiConnection = new KnoraApiConnection(config);
+    const valuesSpyObj = {
+      v2: {
+        values: jasmine.createSpyObj('values', ['updateValue', 'getValue'])
+      }
+    };
 
     TestBed.configureTestingModule({
       imports: [
@@ -121,11 +121,12 @@ describe('DisplayEditComponent', () => {
       providers: [
         {
           provide: KnoraApiConnectionToken,
-          useValue: knoraApiConnection
+          useValue: valuesSpyObj
         }
       ]
     })
       .compileComponents();
+
   }));
 
   describe('change from display to edit mode', () => {
@@ -166,11 +167,11 @@ describe('DisplayEditComponent', () => {
 
     });
 
-    it('should save a new version of a value', inject([KnoraApiConnectionToken], (knoraApiCon) => {
+    it('should save a new version of a value', () => {
 
-      const updateValueSpy = spyOn(knoraApiCon.v2.values, 'updateValue');
+      const valuesSpy = TestBed.get(KnoraApiConnectionToken);
 
-      updateValueSpy.and.callFake(
+      valuesSpy.v2.values.updateValue.and.callFake(
         () => {
 
           const response = new WriteValueResponse();
@@ -182,9 +183,7 @@ describe('DisplayEditComponent', () => {
         }
       );
 
-      const readValueSpy = spyOn(knoraApiCon.v2.values, 'getValue');
-
-      readValueSpy.and.callFake(
+      valuesSpy.v2.values.getValue.and.callFake(
         () => {
 
           const updatedVal = new ReadIntValue();
@@ -221,14 +220,14 @@ describe('DisplayEditComponent', () => {
       testHostFixture.detectChanges();
 
       // expect(updateValueSpy).toHaveBeenCalledWith();
-      expect(updateValueSpy).toHaveBeenCalledTimes(1);
+      expect(valuesSpy.v2.values.updateValue).toHaveBeenCalledTimes(1);
 
-      expect(readValueSpy).toHaveBeenCalledTimes(1);
-      expect(readValueSpy).toHaveBeenCalledWith(testHostComponent.readResource.id, testHostComponent.readValue.uuid);
+      expect(valuesSpy.v2.values.getValue).toHaveBeenCalledTimes(1);
+      expect(valuesSpy.v2.values.getValue).toHaveBeenCalledWith(testHostComponent.readResource.id, testHostComponent.readValue.uuid);
 
       expect(testHostComponent.displayEditValueComponent.displayValue.id).toEqual('newID');
       expect(testHostComponent.displayEditValueComponent.mode).toEqual('read');
-    }));
+    });
 
   });
 });

--- a/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
+++ b/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
@@ -70,12 +70,12 @@ export class DisplayEditComponent implements OnInit {
 
       this.knoraApiConnection.v2.values.updateValue(updateRes as UpdateResource<UpdateValue>).pipe(
         mergeMap((res: WriteValueResponse) => {
-          console.log(res);
+          // console.log(res);
           return this.knoraApiConnection.v2.values.getValue(this.parentResource.id, this.displayValue.uuid);
         })
       ).subscribe(
         (res2: ReadResource) => {
-          console.log(res2);
+          // console.log(res2);
           this.displayValue = res2.getValues(this.displayValue.property)[0];
           this.mode = 'read';
         }


### PR DESCRIPTION
I think I can come up with an alternative to using `inject` in an `it`.

Turns out that `KnoraApiCnnection` can be mocked with a simple object that defines spies for the methods that are actually called by the testes code.