### PR TITLE
Fix Link Value Spec

### DIFF
--- a/projects/knora-ui/src/lib/viewer/values/link-value/link-value.component.html
+++ b/projects/knora-ui/src/lib/viewer/values/link-value/link-value.component.html
@@ -1,6 +1,6 @@
 <span [formGroup]="form">
   <mat-form-field class="example-full-width linkValue-field">
-        <input [formControlName]="'linkValue'" type="text" placeholder="Link value" aria-label="resource" matInput [matAutocomplete]="auto" [readonly]="mode === 'read'">
+        <input matInput [formControlName]="'linkValue'" class="value" type="text" placeholder="Link value" aria-label="resource" [matAutocomplete]="auto" [readonly]="mode === 'read'">
 
         <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayResource">
           <mat-option *ngFor="let res of resources" [value]="res">

--- a/projects/knora-ui/src/lib/viewer/values/link-value/link-value.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/values/link-value/link-value.component.spec.ts
@@ -369,6 +369,9 @@ describe('LinkValueComponent', () => {
     let testHostFixture: ComponentFixture<TestHostCreateValueComponent>;
 
     let valueComponentDe: DebugElement;
+
+    let valueInputDebugElement: DebugElement;
+    let valueInputNativeElement;
     let commentInputDebugElement: DebugElement;
     let commentInputNativeElement;
 
@@ -384,6 +387,10 @@ describe('LinkValueComponent', () => {
       const hostCompDe = testHostFixture.debugElement;
 
       valueComponentDe = hostCompDe.query(By.directive(LinkValueComponent));
+
+      valueInputDebugElement = valueComponentDe.query(By.css('input.value'));
+      valueInputNativeElement = valueInputDebugElement.nativeElement;
+
       commentInputDebugElement = valueComponentDe.query(By.css('input.comment'));
       commentInputNativeElement = commentInputDebugElement.nativeElement;
     });
@@ -453,7 +460,7 @@ describe('LinkValueComponent', () => {
       expect(newValue instanceof CreateLinkValue).toBeFalsy();
     });
 
-    it('should reset form after cancellation', () => {
+    it('should reset form after cancellation', fakeAsync(() => {
 
       // simulate user input
       const res = new ReadResource();
@@ -461,7 +468,12 @@ describe('LinkValueComponent', () => {
       res.label = 'hidden thing';
       testHostComponent.inputValueComponent.valueFormControl.setValue(res);
 
+      // https://github.com/angular/components/blob/29e74eb9431ba01d951ee33df554f465609b59fa/src/material/autocomplete/autocomplete.spec.ts#L2577-L2580
       testHostFixture.detectChanges();
+      tick();
+      testHostFixture.detectChanges();
+
+      expect(valueInputNativeElement.value).toEqual('hidden thing');
 
       commentInputNativeElement.value = 'created comment';
 
@@ -475,12 +487,17 @@ describe('LinkValueComponent', () => {
 
       testHostComponent.inputValueComponent.resetFormControl();
 
+      testHostFixture.detectChanges();
+      tick();
+      testHostFixture.detectChanges();
+
       expect(testHostComponent.inputValueComponent.form.valid).toBeFalsy();
 
       expect(testHostComponent.inputValueComponent.valueFormControl.value).toEqual(null);
 
+      expect(valueInputNativeElement.value).toEqual('');
       expect(commentInputNativeElement.value).toEqual('');
 
-    });
+    }));
   });
 });

--- a/projects/knora-ui/src/lib/viewer/values/link-value/link-value.component.spec.ts
+++ b/projects/knora-ui/src/lib/viewer/values/link-value/link-value.component.spec.ts
@@ -330,6 +330,38 @@ describe('LinkValueComponent', () => {
 
     }));
 
+    it('should set a new display value', fakeAsync(() => {
+
+      // setValue has to be called, otherwise the native input field does not get the label via the displayWith function
+      const res = testHostComponent.inputValueComponent.valueFormControl.value;
+      testHostComponent.inputValueComponent.valueFormControl.setValue(res);
+
+      // https://github.com/angular/components/blob/29e74eb9431ba01d951ee33df554f465609b59fa/src/material/autocomplete/autocomplete.spec.ts#L2577-L2580
+      testHostFixture.detectChanges();
+      tick();
+      testHostFixture.detectChanges();
+
+      expect(valueInputNativeElement.value).toEqual('Sierra');
+
+      const linkedRes = new ReadResource();
+      linkedRes.id = 'newId';
+      linkedRes.label = 'new target';
+
+      const newLink = new ReadLinkValue();
+      newLink.id = 'updatedId';
+      newLink.linkedResourceIri = 'newId';
+      newLink.linkedResource = linkedRes;
+
+      testHostComponent.displayInputVal = newLink;
+
+      testHostFixture.detectChanges();
+      tick();
+      testHostFixture.detectChanges();
+
+      expect(valueInputNativeElement.value).toEqual('new target');
+
+    }));
+
   });
 
   describe('create a new link value', () => {
@@ -385,10 +417,11 @@ describe('LinkValueComponent', () => {
       expect(testHostComponent.inputValueComponent.form.valid).toBeFalsy();
 
       testHostComponent.inputValueComponent.valueFormControl.setValue(res);
-      testHostFixture.detectChanges();
 
       expect(testHostComponent.inputValueComponent.form.valid).toBeTruthy();
+
       expect(testHostComponent.inputValueComponent.valueFormControl.value instanceof ReadResource).toBeTruthy();
+
       const newValue = testHostComponent.inputValueComponent.getNewValue();
       expect(newValue instanceof CreateLinkValue).toBeTruthy();
       expect((newValue as CreateLinkValue).linkedResourceIri).toEqual('http://rdfh.ch/0001/IwMDbs0KQsaxSRUTl2cAIQ');
@@ -421,6 +454,7 @@ describe('LinkValueComponent', () => {
     });
 
     it('should reset form after cancellation', () => {
+
       // simulate user input
       const res = new ReadResource();
       res.id = 'http://rdfh.ch/0001/IwMDbs0KQsaxSRUTl2cAIQ';


### PR DESCRIPTION
This PR fixes a problem that occurred in the specs due to a missing spy (`searchByLabel` was triggered, but no spy was defined for the `it`).

This PR also adds some missing assertions and additional specs for link value. Checking for the active resource's label in the template is tricky. I think it's necessary to do this check because we need to know that the binding between the `FormControl` and the input element works correctly. Probably there is a better solution since we do not want to repeat tests here that are already defined for Angular Material components.

`searchByLabel`s return type should be void. This is because getting the label from Knora is an async operation (`Observable<ReadResource>`). `searchByLabel` assigns the result to `resources` when it's there and then it hets updated in the template.