### PR TITLE
Clean up prop label

### DIFF
--- a/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.scss
+++ b/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.scss
@@ -101,6 +101,6 @@
 .edit .mat-icon,
 .save .mat-icon,
 .cancel .mat-icon {
-    width: 16px;
-    height: 16px;
+    width: 18px;
+    height: 18px;
 }

--- a/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.scss
+++ b/projects/knora-ui/src/lib/viewer/operations/display-edit/display-edit.component.scss
@@ -101,6 +101,6 @@
 .edit .mat-icon,
 .save .mat-icon,
 .cancel .mat-icon {
-    width: 18px;
-    height: 18px;
+    width: 16px;
+    height: 16px;
 }

--- a/projects/knora-ui/src/lib/viewer/views/property-view/property-view.component.html
+++ b/projects/knora-ui/src/lib/viewer/views/property-view/property-view.component.html
@@ -1,16 +1,11 @@
 <div *ngFor="let prop of propArray">
-    <div *ngIf="prop.values">
-
-        <h4 class="label">
-            {{prop.propDef.label}}
-        </h4>
-
-        <div *ngFor="let value of prop.values">
-            <div *ngIf="value">
-                <kui-display-edit #displayEdit [parentResource]="parentResource" [displayValue]="value">
-                </kui-display-edit>
-            </div>
-        </div>
-
+  <div *ngIf="prop.values">
+    <div *ngFor="let value of prop.values">
+      <div *ngIf="value">
+        <kui-display-edit #displayEdit [parentResource]="parentResource" [displayValue]="value">
+        </kui-display-edit>
+      </div>
     </div>
+
+  </div>
 </div>


### PR DESCRIPTION
The property label is displayed twice. 

It has been removed from property-view component (for now).

See [YouTrack issue 149](https://dasch.myjetbrains.com/youtrack/issue/DSP-149)