### PR TITLE
Wip/dsp 227 refactor value components

### DIFF
--- a/projects/knora-ui/src/lib/viewer/values/decimal-value/decimal-value.component.html
+++ b/projects/knora-ui/src/lib/viewer/values/decimal-value/decimal-value.component.html
@@ -5,7 +5,7 @@
 <ng-template #showForm>
     <span [formGroup]="form">
         <mat-form-field class="large-field child-value-component" floatLabel="never">
-            <input matInput [formControlName]="'decimalValue'" class="value" placeholder="Decimal value" type="number">
+            <input matInput [formControlName]="'decimalValue'" class="value" placeholder="Decimal value" type="number" step="0.05">
         </mat-form-field>
         <mat-form-field class="large-field value-component-comment">
             <textarea matInput

--- a/projects/knora-ui/src/lib/viewer/viewer.module.ts
+++ b/projects/knora-ui/src/lib/viewer/viewer.module.ts
@@ -97,7 +97,6 @@ import { FormattedBooleanPipe } from './pipes/formatted-boolean.pipe';
         PropertyViewComponent,
         ResourceViewComponent,
         ListValueComponent,
-        SublistValueComponent,
         GeonameValueComponent,
         KnoraDatePipe,
         FormattedBooleanPipe


### PR DESCRIPTION
- [x] stepsize of input field of decimal value should be a decimal value such as `0.05`. The default stepsize=1 converts a decimal value to an integer value.

- [x] export of `SubListValueComponent` in `viewer.module` causes error messages running the app with angular-devkit 9

closes [DSP-227](https://dasch.myjetbrains.com/youtrack/agiles/110-4/111-29?issue=DSP-227)