### PR TITLE
Prerelease v1.0.0-rc.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm install
       - run: npm run build-lib
-      - run: cd ${{env.dist-directory}} && npm publish --access public --dry-run
+      - run: cd ${{env.dist-directory}} && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN_DASCHBOT}}
       - uses: lakto/gren-action@v1.1.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # DSP-UI library
 
-This is the demo and developing environment for DSP-UI-LIB (@dasch-swiss/dsp-ui) comprised of 4 modules.
+---
+
+![npm (scoped)](https://img.shields.io/npm/v/@dasch-swiss/dsp-ui)
+
+This is the demo and developing environment for DSP-UI-LIB ([@dasch-swiss/dsp-ui](https://www.npmjs.com/package/@dasch-swiss/dsp-ui)) comprised of 4 modules.
 
 The modules help create a GUI to allow the user to use [DSP-API](https://docs.dasch.swiss/developers/knora/api-reference/) in a quick and simple way from within a web application. The modules are written in Typescript for use with [Angular](https://angular.io) (version 9). We decided to style components and directives with [Angular Material design](https://material.angular.io).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dsp-ui-lib",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsp-ui-lib",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/dasch-swiss/knora-ui-ng-lib.git"

--- a/projects/dsp-ui/README.md
+++ b/projects/dsp-ui/README.md
@@ -18,7 +18,7 @@ npm install @dasch-swiss/dsp-ui
 
 The module has the following package dependencies, which you also have to install.
 
-<!-- TODO: the following package will be renamed to @dasch-swiss/dsp-js -->
+<!-- TODO: the following package will be renamed to @dasch-swiss/dsp-js and the list of dependencies incl. version will be added to an external matrix file -->
 - [@knora/api](https://www.npmjs.com/package/@knora/api)
 - [jdnconvertiblecalendar@0.0.5](https://www.npmjs.com/package/jdnconvertiblecalendar)
 - [jdnconvertiblecalendardateadapter@0.0.13](https://www.npmjs.com/package/jdnconvertiblecalendardateadapter)

--- a/projects/dsp-ui/package.json
+++ b/projects/dsp-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dasch-swiss/dsp-ui",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/dasch-swiss/dsp-ui-lib.git"


### PR DESCRIPTION
After merging this PR, we'll create a new release v1.0.0-rc.1 which publishes the first @dasch-swiss/dsp-ui package to npm.